### PR TITLE
Wda fix avoid malformed jwt exception

### DIFF
--- a/wserver/src/main/java/com/wanderdrop/wserver/config/JwtAuthenticationFilter.java
+++ b/wserver/src/main/java/com/wanderdrop/wserver/config/JwtAuthenticationFilter.java
@@ -40,10 +40,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         jwt = authHeader.substring(7);
 
+        if (!jwt.contains(".") || jwt.split("\\.").length != 3) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.getWriter().write("Malformed JWT token");
+            return;
+        }
+
         try {
             userEmail = jwtUtil.extractUsername(jwt);
         } catch (SignatureException e) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.getWriter().write("Invalid JWT signature");
             return;
         }
 

--- a/wserver/src/main/java/com/wanderdrop/wserver/service/attraction/AttractionService.java
+++ b/wserver/src/main/java/com/wanderdrop/wserver/service/attraction/AttractionService.java
@@ -6,12 +6,8 @@ import java.util.List;
 
 public interface AttractionService {
     AttractionDto saveAttraction(AttractionDto attractionDTO);
-
     AttractionDto getAttractionById(Long attractionId);
-
     List<AttractionDto> getAllAttractions();
-
     AttractionDto updateAttraction(Long attractionId, AttractionDto updatedAttraction);
-
     void deleteAttraction(Long attractionId, Long deletionReasonId);
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -1,0 +1,89 @@
+package com.wanderdrop.wserver.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.wanderdrop.wserver.dto.AttractionDto;
+import com.wanderdrop.wserver.model.Attraction;
+import com.wanderdrop.wserver.model.Role;
+import com.wanderdrop.wserver.model.Status;
+import com.wanderdrop.wserver.model.User;
+import com.wanderdrop.wserver.repository.AttractionRepository;
+import com.wanderdrop.wserver.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.sql.Timestamp;
+import java.util.*;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class AttractionControllerTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AttractionRepository attractionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        attractionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void getAllAttractions() throws Exception {
+
+        var response = mockMvc.perform(get("/api/attractions")).andReturn();
+        var attractions = objectMapper.readValue(response.getResponse().getContentAsString(), new TypeReference<List<AttractionDto>>() {
+        });
+
+        assertEquals(new ArrayList<Attraction>(), attractions);
+
+    }
+
+    @Test
+    void testGetAllAttractionsWithUserAndAttractions() throws Exception {
+
+        user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword("password");
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+        Attraction attraction1 = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        Attraction attraction2 = new Attraction(null, "Attraction 2", "Description 2", 32.1234, 17.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction1);
+        attractionRepository.save(attraction2);
+
+        var response = mockMvc.perform(get("/api/attractions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andReturn();
+
+        var attractions = objectMapper.readValue(response.getResponse().getContentAsString(), new TypeReference<List<AttractionDto>>() {
+        });
+        assertEquals(2, attractions.size());
+    }
+
+}

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -224,4 +224,88 @@ class AttractionControllerTest {
                         .content(objectMapper.writeValueAsString(attractionDto)))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    void testAdminUpdateAttraction() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.ADMIN);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest();
+        authenticationRequest.setEmail("testuser@test.com");
+        authenticationRequest.setPassword("password");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.token");
+
+        AttractionDto updatedAttractionDto = new AttractionDto();
+        updatedAttractionDto.setName("Updated Attraction");
+        updatedAttractionDto.setDescription("Updated Description");
+        updatedAttractionDto.setLatitude(33.1234);
+        updatedAttractionDto.setLongitude(17.3545);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId())
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedAttractionDto)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testUserUpdateAttractionShouldFail() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest();
+        authenticationRequest.setEmail("testuser@test.com");
+        authenticationRequest.setPassword("password");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.token");
+
+        AttractionDto updatedAttractionDto = new AttractionDto();
+        updatedAttractionDto.setName("Updated Attraction");
+        updatedAttractionDto.setDescription("Updated Description");
+        updatedAttractionDto.setLatitude(33.1234);
+        updatedAttractionDto.setLongitude(17.3545);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId())
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedAttractionDto)))
+                .andExpect(status().isForbidden());
+    }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.jsonpath.JsonPath;
 import com.wanderdrop.wserver.dto.AttractionDto;
 import com.wanderdrop.wserver.dto.AuthenticationRequest;
-import com.wanderdrop.wserver.mapper.AttractionMapper;
 import com.wanderdrop.wserver.model.Attraction;
 import com.wanderdrop.wserver.model.Role;
 import com.wanderdrop.wserver.model.Status;
@@ -18,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.test.web.servlet.MvcResult;
@@ -310,6 +308,34 @@ class AttractionControllerTest {
     }
 
     @Test
+    void testUpdateAttractionUnauthorizedShouldFail() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.ADMIN);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        AttractionDto updatedAttractionDto = new AttractionDto();
+        updatedAttractionDto.setName("Updated Attraction");
+        updatedAttractionDto.setDescription("Updated Description");
+        updatedAttractionDto.setLatitude(33.1234);
+        updatedAttractionDto.setLongitude(17.3545);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedAttractionDto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void testAdminDeleteAttraction() throws Exception {
 
         User user = new User();
@@ -374,6 +400,26 @@ class AttractionControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId() + "/1")
                         .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testDeleteAttractionUnauthorizedShouldFail() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.ADMIN);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId() + "/1"))
                 .andExpect(status().isForbidden());
     }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -1,7 +1,10 @@
 package com.wanderdrop.wserver.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.jayway.jsonpath.JsonPath;
 import com.wanderdrop.wserver.dto.AttractionDto;
+import com.wanderdrop.wserver.dto.AuthenticationRequest;
+import com.wanderdrop.wserver.mapper.AttractionMapper;
 import com.wanderdrop.wserver.model.Attraction;
 import com.wanderdrop.wserver.model.Role;
 import com.wanderdrop.wserver.model.Status;
@@ -13,8 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.sql.Timestamp;
 import java.util.*;
@@ -22,6 +30,7 @@ import java.util.*;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -49,7 +58,7 @@ class AttractionControllerTest {
     }
 
     @Test
-    void getAllAttractions() throws Exception {
+    void testGetAllAttractions() throws Exception {
 
         var response = mockMvc.perform(get("/api/attractions")).andReturn();
         var attractions = objectMapper.readValue(response.getResponse().getContentAsString(), new TypeReference<List<AttractionDto>>() {
@@ -86,4 +95,64 @@ class AttractionControllerTest {
         assertEquals(2, attractions.size());
     }
 
+
+    @Test
+    void testGetAttractionById() throws Exception {
+
+        user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword("password");
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/attractions/{id}", attraction.getAttractionId()))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    void testCreateAttraction() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest();
+        authenticationRequest.setEmail("testuser@test.com");
+        authenticationRequest.setPassword("password");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.token");
+
+        AttractionDto attractionDto = new AttractionDto();
+        attractionDto.setName("New Attraction");
+        attractionDto.setDescription("New Description");
+        attractionDto.setLatitude(22.1234);
+        attractionDto.setLongitude(16.3545);
+
+        mockMvc.perform(post("/api/attractions")
+                        .header("Authorization", "Bearer " + token)  // Include the token in the header
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(attractionDto)))
+                .andExpect(status().isOk());
+    }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -308,4 +308,72 @@ class AttractionControllerTest {
                         .content(objectMapper.writeValueAsString(updatedAttractionDto)))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    void testAdminDeleteAttraction() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.ADMIN);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest();
+        authenticationRequest.setEmail("testuser@test.com");
+        authenticationRequest.setPassword("password");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.token");
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId() + "/1")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testUserDeleteAttractionShouldFail() throws Exception {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword(new BCryptPasswordEncoder().encode("password"));
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        AuthenticationRequest authenticationRequest = new AuthenticationRequest();
+        authenticationRequest.setEmail("testuser@test.com");
+        authenticationRequest.setPassword("password");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authenticationRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.token");
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/attractions/" + attraction.getAttractionId() + "/1")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/controller/AttractionControllerTest.java
@@ -10,6 +10,7 @@ import com.wanderdrop.wserver.model.Status;
 import com.wanderdrop.wserver.model.User;
 import com.wanderdrop.wserver.repository.AttractionRepository;
 import com.wanderdrop.wserver.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,8 +50,8 @@ class AttractionControllerTest {
 
     private User user;
 
-    @BeforeEach
-    void setUp() {
+    @AfterEach
+    void tearDown() {
         attractionRepository.deleteAll();
         userRepository.deleteAll();
     }

--- a/wserver/src/test/java/com/wanderdrop/wserver/mapper/AttractionMapperTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/mapper/AttractionMapperTest.java
@@ -1,0 +1,87 @@
+package com.wanderdrop.wserver.mapper;
+
+import com.wanderdrop.wserver.dto.AttractionDto;
+import com.wanderdrop.wserver.model.Attraction;
+import com.wanderdrop.wserver.model.Status;
+import com.wanderdrop.wserver.model.User;
+import com.wanderdrop.wserver.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttractionMapperTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    public void testMapToAttractionDto() {
+        User createdBy = new User();
+        createdBy.setUserId(UUID.randomUUID());
+
+        User updatedBy = new User();
+        updatedBy.setUserId(UUID.randomUUID());
+
+        Attraction attraction = new Attraction();
+        attraction.setAttractionId(1L);
+        attraction.setName("Test Attraction");
+        attraction.setDescription("Description");
+        attraction.setLatitude(123.45);
+        attraction.setLongitude(67.89);
+        attraction.setStatus(Status.ACTIVE);
+        attraction.setCreatedBy(createdBy);
+        attraction.setUpdatedBy(updatedBy);
+        attraction.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        attraction.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        AttractionDto attractionDto = AttractionMapper.mapToAttractionDto(attraction);
+
+        assertNotNull(attractionDto);
+        assertEquals(attraction.getAttractionId(), attractionDto.getAttractionId());
+        assertEquals(attraction.getName(), attractionDto.getName());
+        assertEquals(attraction.getDescription(), attractionDto.getDescription());
+        assertEquals(attraction.getLatitude(), attractionDto.getLatitude());
+        assertEquals(attraction.getLongitude(), attractionDto.getLongitude());
+        assertEquals(attraction.getStatus(), attractionDto.getStatus());
+        assertEquals(attraction.getCreatedBy().getUserId(), attractionDto.getCreatedBy());
+        assertEquals(attraction.getUpdatedBy().getUserId(), attractionDto.getUpdatedBy());
+        assertEquals(attraction.getCreatedAt(), attractionDto.getCreatedAt());
+        assertEquals(attraction.getUpdatedAt(), attractionDto.getUpdatedAt());
+    }
+
+    @Test
+    public void testMapToAttraction_UserNotFound() {
+        UUID createdById = UUID.randomUUID();
+        UUID updatedById = UUID.randomUUID();
+
+        AttractionDto attractionDto = new AttractionDto();
+        attractionDto.setAttractionId(1L);
+        attractionDto.setName("Test Attraction");
+        attractionDto.setDescription("Description");
+        attractionDto.setLatitude(123.45);
+        attractionDto.setLongitude(67.89);
+        attractionDto.setStatus(Status.ACTIVE);
+        attractionDto.setCreatedBy(createdById);
+        attractionDto.setUpdatedBy(updatedById);
+        attractionDto.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        attractionDto.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        when(userRepository.findById(createdById)).thenReturn(Optional.empty());
+        when(userRepository.findById(updatedById)).thenReturn(Optional.empty());
+
+        Attraction attraction = AttractionMapper.mapToAttraction(attractionDto, userRepository);
+
+        assertNotNull(attraction);
+        assertNull(attraction.getCreatedBy());
+        assertNull(attraction.getUpdatedBy());
+    }
+}

--- a/wserver/src/test/java/com/wanderdrop/wserver/repository/AttractionRepositoryTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/repository/AttractionRepositoryTest.java
@@ -3,8 +3,8 @@ package com.wanderdrop.wserver.repository;
 import com.wanderdrop.wserver.model.Attraction;
 import com.wanderdrop.wserver.model.Role;
 import com.wanderdrop.wserver.model.Status;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -12,6 +12,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import com.wanderdrop.wserver.model.User;
 
 import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,20 +24,14 @@ public class AttractionRepositoryTest {
     @Autowired
     private AttractionRepository attractionRepository;
 
+    private User user;
+
     @Autowired
     private UserRepository userRepository;
 
-    @AfterEach
-    void tearDown() {
-        attractionRepository.deleteAll();
-        userRepository.deleteAll();
-    }
-
-    @Test
-    @Transactional
-    public void testSaveAttraction() {
-
-        User user = new User();
+    @BeforeEach
+    void setUp() {
+        user = new User();
         user.setEmail("testuser@test.com");
         user.setPassword("password");
         user.setFirstName("Firstname");
@@ -44,6 +40,46 @@ public class AttractionRepositoryTest {
         user.setStatus(Status.ACTIVE);
         user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
         userRepository.save(user);
+    }
+
+
+    @AfterEach
+    void tearDown() {
+        attractionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void testFindNonExistingAttraction() {
+        Optional<Attraction> found = attractionRepository.findById(999L);
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    public void testFindAttractionById() {
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        Attraction found = attractionRepository.findById(attraction.getAttractionId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("Attraction 1");
+    }
+
+    @Test
+    public void testGetAllAttractions() {
+        Attraction attraction1 = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        Attraction attraction2 = new Attraction(null, "Attraction 2", "Description 2", 32.1234, 17.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction1);
+        attractionRepository.save(attraction2);
+
+        List<Attraction> attractions = attractionRepository.findAll();
+
+        assertThat(attractions).hasSize(2);
+        assertThat(attractions).contains(attraction1, attraction2);
+    }
+
+    @Test
+    public void testSaveAttraction() {
 
         Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
 
@@ -53,5 +89,31 @@ public class AttractionRepositoryTest {
         assertThat(found).isNotNull();
         assert found != null;
         assertThat(found.getName()).isEqualTo("Attraction 1");
+    }
+
+    @Test
+    public void testUpdateAttraction() {
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        attraction.setName("Updated Attraction");
+        attractionRepository.save(attraction);
+
+        Attraction found = attractionRepository.findById(attraction.getAttractionId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getName()).isEqualTo("Updated Attraction");
+    }
+
+    @Test
+    public void testDeleteAttraction() {
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+        attractionRepository.save(attraction);
+
+        attractionRepository.delete(attraction);
+
+        Optional<Attraction> found = attractionRepository.findById(attraction.getAttractionId());
+        assertThat(found).isEmpty();
     }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/repository/AttractionRepositoryTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/repository/AttractionRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.wanderdrop.wserver.repository;
+
+import com.wanderdrop.wserver.model.Attraction;
+import com.wanderdrop.wserver.model.Role;
+import com.wanderdrop.wserver.model.Status;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import com.wanderdrop.wserver.model.User;
+
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class AttractionRepositoryTest {
+
+    @Autowired
+    private AttractionRepository attractionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        attractionRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    public void testSaveAttraction() {
+
+        User user = new User();
+        user.setEmail("testuser@test.com");
+        user.setPassword("password");
+        user.setFirstName("Firstname");
+        user.setLastName("Lastname");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+        user.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        userRepository.save(user);
+
+        Attraction attraction = new Attraction(null, "Attraction 1", "Description 1", 22.1234, 16.3545, user, user, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), Status.ACTIVE, null);
+
+        attractionRepository.save(attraction);
+
+        Attraction found = attractionRepository.findById(attraction.getAttractionId()).orElse(null);
+        assertThat(found).isNotNull();
+        assert found != null;
+        assertThat(found.getName()).isEqualTo("Attraction 1");
+    }
+}

--- a/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
@@ -133,4 +133,30 @@ class AttractionServiceImplTest {
         verify(attractionRepository, never()).save(any(Attraction.class));
     }
 
+    @Test
+    public void testGetAttractionById() {
+        Attraction attraction = new Attraction();
+        attraction.setAttractionId(1L);
+        attraction.setName("Test Attraction");
+        attraction.setDescription("Description");
+        attraction.setStatus(Status.ACTIVE);
+
+        when(attractionRepository.findById(1L)).thenReturn(Optional.of(attraction));
+
+        AttractionDto attractionDto = attractionService.getAttractionById(1L);
+
+        assertNotNull(attractionDto);
+        assertEquals(attraction.getName(), attractionDto.getName());
+        verify(attractionRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    public void testGetAttractionById_NotFound() {
+        when(attractionRepository.findById(1L)).thenReturn(Optional.empty());
+
+        AttractionDto attractionDto = attractionService.getAttractionById(1L);
+
+        assertNull(attractionDto);
+        verify(attractionRepository, times(1)).findById(1L);
+    }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.wanderdrop.wserver.service.attraction;
+
+import com.wanderdrop.wserver.dto.AttractionDto;
+import com.wanderdrop.wserver.model.Attraction;
+import com.wanderdrop.wserver.model.Role;
+import com.wanderdrop.wserver.model.Status;
+import com.wanderdrop.wserver.model.User;
+import com.wanderdrop.wserver.repository.AttractionRepository;
+import com.wanderdrop.wserver.repository.DeletionReasonRepository;
+import com.wanderdrop.wserver.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttractionServiceImplTest {
+
+    @Mock
+    private AttractionRepository attractionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private DeletionReasonRepository deletionReasonRepository;
+
+    @InjectMocks
+    private AttractionServiceImpl attractionService;
+
+    private User mockAdminUser;
+    private User mockRegularUser;
+
+    @BeforeEach
+    public void setUp() {
+        mockAdminUser = new User();
+        mockAdminUser.setUserId(UUID.randomUUID());
+        mockAdminUser.setEmail("admin@example.com");
+        mockAdminUser.setRole(Role.ADMIN);
+
+        mockRegularUser = new User();
+        mockRegularUser.setUserId(UUID.randomUUID());
+        mockRegularUser.setEmail("user@example.com");
+        mockRegularUser.setRole(Role.USER);
+    }
+
+    private void setAuthenticatedUser(User user) {
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(user.getEmail());
+        SecurityContextHolder.setContext(securityContext);
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+    }
+
+    @Test
+    public void testSaveAttraction_AsAdmin() {
+        setAuthenticatedUser(mockAdminUser);
+
+        AttractionDto attractionDto = new AttractionDto();
+        attractionDto.setName("Test Attraction");
+        attractionDto.setDescription("Description");
+
+        Attraction attraction = new Attraction();
+        attraction.setAttractionId(1L);
+        attraction.setName("Test Attraction");
+        attraction.setDescription("Description");
+        attraction.setStatus(Status.ACTIVE);
+        attraction.setCreatedBy(mockAdminUser);
+        attraction.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        when(attractionRepository.save(any(Attraction.class))).thenReturn(attraction);
+
+        AttractionDto savedAttraction = attractionService.saveAttraction(attractionDto);
+
+        assertNotNull(savedAttraction);
+        assertEquals(attraction.getName(), savedAttraction.getName());
+        verify(attractionRepository, times(1)).save(any(Attraction.class));
+    }
+
+    @Test
+    public void testSaveAttraction_AsUser() {
+        setAuthenticatedUser(mockRegularUser);
+
+        AttractionDto attractionDto = new AttractionDto();
+        attractionDto.setName("Test Attraction");
+        attractionDto.setDescription("Description");
+
+        Attraction attraction = new Attraction();
+        attraction.setAttractionId(1L);
+        attraction.setName("Test Attraction");
+        attraction.setDescription("Description");
+        attraction.setStatus(Status.ACTIVE);
+        attraction.setCreatedBy(mockRegularUser);
+        attraction.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        when(attractionRepository.save(any(Attraction.class))).thenReturn(attraction);
+
+        AttractionDto savedAttraction = attractionService.saveAttraction(attractionDto);
+
+        assertNotNull(savedAttraction);
+        assertEquals(attraction.getName(), savedAttraction.getName());
+        verify(attractionRepository, times(1)).save(any(Attraction.class));
+    }
+
+    @Test
+    public void testSaveAttraction_Unauthorized() {
+        setAuthenticatedUser(new User());
+
+        AttractionDto attractionDto = new AttractionDto();
+
+        AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
+            attractionService.saveAttraction(attractionDto);
+        });
+
+        assertEquals("Only logged in users and admins can create an attraction.", exception.getMessage());
+        verify(attractionRepository, never()).save(any(Attraction.class));
+    }
+
+}

--- a/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
@@ -183,4 +183,49 @@ class AttractionServiceImplTest {
         assertEquals(2, attractionDtos.size());
         verify(attractionRepository, times(1)).findAll();
     }
+
+    @Test
+    public void testUpdateAttraction() {
+        setAuthenticatedUser(mockAdminUser);
+
+        Attraction existingAttraction = new Attraction();
+        existingAttraction.setAttractionId(1L);
+        existingAttraction.setName("Old Attraction");
+        existingAttraction.setDescription("Old Description");
+        existingAttraction.setStatus(Status.ACTIVE);
+        existingAttraction.setCreatedBy(mockAdminUser);
+        existingAttraction.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        AttractionDto updatedAttractionDto = new AttractionDto();
+        updatedAttractionDto.setName("Updated Attraction");
+        updatedAttractionDto.setDescription("Updated Description");
+
+        when(attractionRepository.findById(1L)).thenReturn(Optional.of(existingAttraction));
+        when(attractionRepository.save(any(Attraction.class))).thenReturn(existingAttraction);
+
+        AttractionDto updatedAttraction = attractionService.updateAttraction(1L, updatedAttractionDto);
+
+        assertNotNull(updatedAttraction);
+        assertEquals(updatedAttractionDto.getName(), updatedAttraction.getName());
+        assertEquals(updatedAttractionDto.getDescription(), updatedAttraction.getDescription());
+        verify(attractionRepository, times(1)).findById(1L);
+        verify(attractionRepository, times(1)).save(any(Attraction.class));
+    }
+
+    @Test
+    public void testUpdateAttraction_NotFound() {
+        setAuthenticatedUser(mockAdminUser);
+
+        AttractionDto updatedAttractionDto = new AttractionDto();
+        updatedAttractionDto.setName("Updated Attraction");
+        updatedAttractionDto.setDescription("Updated Description");
+
+        when(attractionRepository.findById(1L)).thenReturn(Optional.empty());
+
+        AttractionDto updatedAttraction = attractionService.updateAttraction(1L, updatedAttractionDto);
+
+        assertNull(updatedAttraction);
+        verify(attractionRepository, times(1)).findById(1L);
+        verify(attractionRepository, never()).save(any(Attraction.class));
+    }
 }

--- a/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
+++ b/wserver/src/test/java/com/wanderdrop/wserver/service/attraction/AttractionServiceImplTest.java
@@ -20,12 +20,13 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -158,5 +159,28 @@ class AttractionServiceImplTest {
 
         assertNull(attractionDto);
         verify(attractionRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    public void testGetAllAttractions() {
+        Attraction attraction1 = new Attraction();
+        attraction1.setAttractionId(1L);
+        attraction1.setName("Test Attraction 1");
+        attraction1.setDescription("Description 1");
+        attraction1.setStatus(Status.ACTIVE);
+
+        Attraction attraction2 = new Attraction();
+        attraction2.setAttractionId(2L);
+        attraction2.setName("Test Attraction 2");
+        attraction2.setDescription("Description 2");
+        attraction2.setStatus(Status.ACTIVE);
+
+        when(attractionRepository.findAll()).thenReturn(Arrays.asList(attraction1, attraction2));
+
+        List<AttractionDto> attractionDtos = attractionService.getAllAttractions();
+
+        assertNotNull(attractionDtos);
+        assertEquals(2, attractionDtos.size());
+        verify(attractionRepository, times(1)).findAll();
     }
 }

--- a/wserver/src/test/resources/application.properties
+++ b/wserver/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/wanderdropdb_test?createDatabaseIfNotExist=true
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Fix unhandled exception related to MalformedJwt. Add a check for the JWT token format before trying to parse it to avoid the MalformedJwtException. If the token is malformed, return a 403 Forbidden status with a “Malformed JWT token” message. Provide a more informative error message to the client.